### PR TITLE
Pod-Level spec instead of Top-Level spec

### DIFF
--- a/docs/gke.md
+++ b/docs/gke.md
@@ -2,38 +2,38 @@
 
 This guide shows you how to deploy Percona Operator for MongoDB on Google
 Kubernetes Engine (GKE). The document assumes some experience with the platform.
-For more information on the GKE, see the [Kubernetes Engine Quickstart  :octicons-link-external-16:](https://cloud.google.com/kubernetes-engine/docs/quickstart).
+For more information on the GKE, see the [Kubernetes Engine Quickstart :octicons-link-external-16:](https://cloud.google.com/kubernetes-engine/docs/quickstart).
 
 ## Prerequisites
 
 All commands from this guide can be run either in the **Google Cloud shell** or in **your local shell**.
 
-To use *Google Cloud shell*, you need nothing but a modern web browser.
+To use _Google Cloud shell_, you need nothing but a modern web browser.
 
-If you would like to use *your local shell*, install the following:
+If you would like to use _your local shell_, install the following:
 
-1. [gcloud  :octicons-link-external-16:](https://cloud.google.com/sdk/docs/quickstarts). This tool is
-    part of the Google Cloud SDK. To install it, select your operating
-    system on the [official Google Cloud SDK documentation page  :octicons-link-external-16:](https://cloud.google.com/sdk/docs)
-    and then follow the instructions.
+1. [gcloud :octicons-link-external-16:](https://cloud.google.com/sdk/docs/quickstarts). This tool is
+   part of the Google Cloud SDK. To install it, select your operating
+   system on the [official Google Cloud SDK documentation page :octicons-link-external-16:](https://cloud.google.com/sdk/docs)
+   and then follow the instructions.
 
-2. [kubectl  :octicons-link-external-16:](https://cloud.google.com/kubernetes-engine/docs/quickstart#choosing_a_shell).
-    It is the Kubernetes command-line tool you will use to manage and deploy
-    applications. To install the tool, run the following command:
+2. [kubectl :octicons-link-external-16:](https://cloud.google.com/kubernetes-engine/docs/quickstart#choosing_a_shell).
+   It is the Kubernetes command-line tool you will use to manage and deploy
+   applications. To install the tool, run the following command:
 
-    ``` {.bash data-prompt="$" }
-    $ gcloud auth login
-    $ gcloud components install kubectl
-    ```
+   ```{.bash data-prompt="$" }
+   $ gcloud auth login
+   $ gcloud components install kubectl
+   ```
 
 ## Create and configure the GKE cluster
 
 You can configure the settings using the `gcloud` tool. You can run it either in
-the [Cloud Shell  :octicons-link-external-16:](https://cloud.google.com/shell/docs/quickstart) or in your
+the [Cloud Shell :octicons-link-external-16:](https://cloud.google.com/shell/docs/quickstart) or in your
 local shell (if you have installed Google Cloud SDK locally on the previous
 step). The following command will create a cluster named `my-cluster-name`:
 
-``` {.bash data-prompt="$" }
+```{.bash data-prompt="$" }
 $ gcloud container clusters create my-cluster-name --project <project ID> --zone us-central1-a --cluster-version {{ gkerecommended }} --machine-type n1-standard-4 --num-nodes=3
 ```
 
@@ -52,20 +52,20 @@ You may wait a few minutes for the cluster to be generated.
 Now you should configure the command-line access to your newly created cluster
 to make `kubectl` be able to use it.
 
-In the Google Cloud Console, select your cluster and then click the *Connect*
+In the Google Cloud Console, select your cluster and then click the _Connect_
 shown on the above image. You will see the connect statement which configures
 the command-line access. After you have edited the statement, you may run the
 command in your local shell:
 
-``` {.bash data-prompt="$" }
+```{.bash data-prompt="$" }
 $ gcloud container clusters get-credentials my-cluster-name --zone us-central1-a --project <project name>
 ```
 
-Finally, use your [Cloud Identity and Access Management (Cloud IAM)  :octicons-link-external-16:](https://cloud.google.com/iam)
+Finally, use your [Cloud Identity and Access Management (Cloud IAM) :octicons-link-external-16:](https://cloud.google.com/iam)
 to control access to the cluster. The following command will give you the
 ability to create Roles and RoleBindings:
 
-``` {.bash data-prompt="$" }
+```{.bash data-prompt="$" }
 $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value core/account)
 ```
 
@@ -77,21 +77,21 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
 
 ## Install the Operator and deploy your MongoDB cluster
 
-1. Deploy the Operator. By default deployment will be done in the `default`
+1.  Deploy the Operator. By default deployment will be done in the `default`
     namespace. If that's not the desired one, you can create a new namespace
     and/or set the context for the namespace as follows (replace the `<namespace name>` placeholder with some descriptive name):
 
-    ``` {.bash data-prompt="$" }
+    ```{.bash data-prompt="$" }
     $ kubectl create namespace <namespace name>
     $ kubectl config set-context $(kubectl config current-context) --namespace=<namespace name>
     ```
 
     At success, you will see the message that `namespace/<namespace name>` was created, and the context (`gke_<project name>_<zone location>_<cluster name>`) was modified.
 
-    Deploy the Operator by applying the `deploy/bundle.yaml` manifest from the Operator source tree. 
-    
+    Deploy the Operator by applying the `deploy/bundle.yaml` manifest from the Operator source tree.
+
     === "For x86_64 architecture"
-    
+
         You can apply it without downloading, [using :octicons-link-external-16:](https://kubernetes.io/docs/reference/using-api/server-side-apply/) the following command:
 
         ``` {.bash data-prompt="$" }
@@ -105,13 +105,13 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
             customresourcedefinition.apiextensions.k8s.io/perconaservermongodbbackups.psmdb.percona.com serverside-applied
             customresourcedefinition.apiextensions.k8s.io/perconaservermongodbrestores.psmdb.percona.com serverside-applied
             role.rbac.authorization.k8s.io/percona-server-mongodb-operator serverside-applied
-            serviceaccount/percona-server-mongodb-operator serverside-applied    
+            serviceaccount/percona-server-mongodb-operator serverside-applied
             rolebinding.rbac.authorization.k8s.io/service-account-percona-server-mongodb-operator serverside-applied
             deployment.apps/percona-server-mongodb-operator serverside-applied
             ```
 
     === "For ARM64 architecture"
-    
+
         Clone the repository with all manifests and source code by executing the following command:
 
         ``` {.bash data-prompt="$" }
@@ -119,29 +119,38 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
         ```
 
         Edit the `deploy/bundle.yaml` file: add the following [affinity rules](constraints.md#affinity-and-anti-affinity) to the  `spec` part of the `percona-server-mongodb-operator` Deployment:
-        
+
         ```yaml hl_lines="6-14"
             apiVersion: apps/v1
             kind: Deployment
             metadata:
               name: percona-server-mongodb-operator
             spec:
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                      - matchExpressions:
-                          - key: kubernetes.io/arch
-                            operator: In
-                            values:
-                              - arm64
+              replicas: 1
+              selector:
+                matchLabels:
+                  name: percona-server-mongodb-operator
+              template:
+                metadata:
+                  labels:
+                    name: percona-server-mongodb-operator
+                spec:
+                  affinity:
+                    nodeAffinity:
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        nodeSelectorTerms:
+                          - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - arm64
         ```
 
         After editing, [apply :octicons-link-external-16:](https://kubernetes.io/docs/reference/using-api/server-side-apply/) your modified `deploy/bundle.yaml` file as follows:
 
         ``` {.bash data-prompt="$" }
         $ kubectl apply --server-side -f deploy/bundle.yaml
-        ```       
+        ```
 
         ??? example "Expected output"
 
@@ -150,15 +159,14 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
             customresourcedefinition.apiextensions.k8s.io/perconaservermongodbbackups.psmdb.percona.com serverside-applied
             customresourcedefinition.apiextensions.k8s.io/perconaservermongodbrestores.psmdb.percona.com serverside-applied
             role.rbac.authorization.k8s.io/percona-server-mongodb-operator serverside-applied
-            serviceaccount/percona-server-mongodb-operator serverside-applied    
+            serviceaccount/percona-server-mongodb-operator serverside-applied
             rolebinding.rbac.authorization.k8s.io/service-account-percona-server-mongodb-operator serverside-applied
             deployment.apps/percona-server-mongodb-operator serverside-applied
             ```
 
-2. The Operator has been started, and you can deploy your MongoDB cluster:
-    
+2.  The Operator has been started, and you can deploy your MongoDB cluster:
+
     === "For x86_64 architecture"
-      
 
         ``` {.bash data-prompt="$" }
         $ kubectl apply -f https://raw.githubusercontent.com/percona/percona-server-mongodb-operator/v{{ release }}/deploy/cr.yaml
@@ -185,7 +193,7 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
             ```
 
     === "For ARM64 architecture"
-    
+
         Edit the `deploy/cr.yaml` file: set the following [affinity rules](constraints.md#affinity-and-anti-affinity) in **all `affinity` subsections**:
 
         ```yaml hl_lines="2-11"
@@ -231,7 +239,7 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
     cluster will obtain the `ready` status. You can check it with the following
     command:
 
-    ``` {.bash data-prompt="$" }
+    ```{.bash data-prompt="$" }
     $ kubectl get psmdb
     ```
 
@@ -248,7 +256,6 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
 
     ![image](assets/images/gke-quickstart-object-browser.svg)
 
-
 ## Verifying the cluster operation
 
 It may take ten minutes to get the cluster started. When `kubectl get psmdb`
@@ -259,10 +266,10 @@ to the cluster.
 
 ## Troubleshooting
 
-If `kubectl get psmdb` command doesn't show `ready` status too long, you can 
+If `kubectl get psmdb` command doesn't show `ready` status too long, you can
 check the creation process with the `kubectl get pods` command:
 
-``` {.bash data-prompt="$" }
+```{.bash data-prompt="$" }
 $ kubectl get pods
 ```
 
@@ -273,7 +280,7 @@ $ kubectl get pods
 If the command output had shown some errors, you can examine the problematic
 Pod with the `kubectl describe <pod name>` command as follows:
 
-``` {.bash data-prompt="$" }
+```{.bash data-prompt="$" }
 $ kubectl describe pod my-cluster-name-rs0-2
 ```
 
@@ -299,7 +306,7 @@ There are several ways that you can delete the cluster.
 
 You can clean up the cluster with the `gcloud` command as follows:
 
-``` {.bash data-prompt="$" }
+```{.bash data-prompt="$" }
 $ gcloud container clusters delete <cluster name> --zone us-central1-a --project <project ID>
 ```
 

--- a/docs/gke.md
+++ b/docs/gke.md
@@ -8,9 +8,9 @@ For more information on the GKE, see the [Kubernetes Engine Quickstart :octicons
 
 All commands from this guide can be run either in the **Google Cloud shell** or in **your local shell**.
 
-To use _Google Cloud shell_, you need nothing but a modern web browser.
+To use *Google Cloud shell*, you need nothing but a modern web browser.
 
-If you would like to use _your local shell_, install the following:
+If you would like to use *your local shell*, install the following:
 
 1. [gcloud :octicons-link-external-16:](https://cloud.google.com/sdk/docs/quickstarts). This tool is
    part of the Google Cloud SDK. To install it, select your operating
@@ -52,7 +52,7 @@ You may wait a few minutes for the cluster to be generated.
 Now you should configure the command-line access to your newly created cluster
 to make `kubectl` be able to use it.
 
-In the Google Cloud Console, select your cluster and then click the _Connect_
+In the Google Cloud Console, select your cluster and then click the *Connect*
 shown on the above image. You will see the connect statement which configures
 the command-line access. After you have edited the statement, you may run the
 command in your local shell:
@@ -120,7 +120,7 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
 
         Edit the `deploy/bundle.yaml` file: add the following [affinity rules](constraints.md#affinity-and-anti-affinity) to the  `spec` part of the `percona-server-mongodb-operator` Deployment:
 
-        ```yaml hl_lines="6-14"
+        ```yaml hl_lines="15-23"
             apiVersion: apps/v1
             kind: Deployment
             metadata:
@@ -164,7 +164,7 @@ $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-
             deployment.apps/percona-server-mongodb-operator serverside-applied
             ```
 
-2.  The Operator has been started, and you can deploy your MongoDB cluster:
+3.  The Operator has been started, and you can deploy your MongoDB cluster:
 
     === "For x86_64 architecture"
 


### PR DESCRIPTION
Hi! 

While installing the operator on GKE, I encountered a syntax error. I believe the affinity should be defined at the Pod level rather than at the deployment level.

`Error from server: failed to create typed patch object (mongodbns/percona-server-mongodb-operator; apps/v1, Kind=Deployment): .spec.affinity: field not declared in schema`

**Image: Current Documentation**
![Screenshot 2024-09-20 at 10 36 01](https://github.com/user-attachments/assets/104de6ad-0899-4390-b5ed-be6030cb74bf)
