### PR TITLE
Update MongoDB Community Operator to MCK in comparison

### DIFF
--- a/docs/compare.md
+++ b/docs/compare.md
@@ -6,7 +6,7 @@ There are multiple ways to deploy and manage MongoDB in Kubernetes. Here we will
 
 * [KubeDB  :octicons-link-external-16:](https://github.com/kubedb)
 
-* [MongoDB Community Operator  :octicons-link-external-16:](https://github.com/mongodb/mongodb-kubernetes)
+* [MongoDB Controllers for Kubernetes (MCK)  :octicons-link-external-16:](https://github.com/mongodb/mongodb-kubernetes)
 
 * [Percona Operator for MongoDB  :octicons-link-external-16:](https://github.com/percona/percona-server-mongodb-operator/)
 
@@ -14,14 +14,13 @@ There are multiple ways to deploy and manage MongoDB in Kubernetes. Here we will
 
 Here is the review of generic features, such as supported MongoDB versions, open source models and more.
 
-| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Community Operator         | MongoDB Enterprise Operator  |
-|:------------------|:-----------------------------|:-------------------|:-------------------|:-----------------------------------|:-----------------------------|
-| Open source model | Apache 2.0                   | Apache 2.0         | Open core          | Open core                          | Open core                    |
-| MongoDB versions  | MongoDB 5.0, 6.0, 7.0 \*     | MongoDB 5.0        | MongoDB 3.4, 3.6. 4.0, 4.1, 4.2 | MongoDB 4.2, 4.4, 5.0, 6.0, 7.0| MongoDB 4.2, 4.4, 5.0, 6.0, 7.0|
-| Kubernetes conformance | Various versions are tested | No guarantee   | No guarantee       | No guarantee                       | No guarantee                 |
-| Cluster-wide mode | Yes                          | Not an operator    | Enterprise only    | Yes                                | Yes                          |
-| Network exposure  | Yes                          | Yes                | No, only through manual config | No                     | Yes                          |
-| Web-based GUI     | [Percona Everest](https://docs.percona.com/everest/index.html) | :no_entry_sign: | [kubedb-ui](https://kubedb.com/datasheet/) | :no_entry_sign:| [Ops Manager](https://www.mongodb.com/products/self-managed/enterprise-advanced/ops-manager)|
+| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Controllers for Kubernetes (MCK) | 
+|:------------------|:-----------------------------|:-------------------|:-------------------|:-----------------------------------------|
+| Open source model | Apache 2.0                   | Apache 2.0         | Open core          | Open core                          |
+| Kubernetes conformance | ÇNCF-certified distributions | No guarantee  | No guarantee       | No guarantee                       |
+| Cluster-wide mode | Yes                          | Not an operator    | Enterprise only    | Yes                                |
+| Network exposure  | Yes                          | Yes                | No, only through manual config | Yes (Enterprise); limited (Community) |
+| Web-based GUI     | [OpenEverest](https://openeverest.io/) | :no_entry_sign: | [kubedb-ui](https://kubedb.com/datasheet/) | [Ops Manager / Cloud Manager](https://www.mongodb.com/products/self-managed/enterprise-advanced/ops-manager) (Enterprise)|
 
 \* Percona Operator relies on [Percona Server for MongoDB](https://www.percona.com/mongodb/software/percona-server-for-mongodb) - a free, enhanced, fully compatible MongoDB software alternative for MongoDB Community Server with enterprise-grade features.
 
@@ -29,55 +28,54 @@ Here is the review of generic features, such as supported MongoDB versions, open
 
 Upgrade and scaling are the two most common maintenance tasks that are executed by database administrators and developers.
 
-| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Community Operator        | MongoDB Enterprise Operator       |
-|:------------------|:-----------------------------|:-------------------|:-------------------|:----------------------------------|:----------------------------------|
-| Operator upgrade  | Yes                          | Helm upgrade       | Image change       | Yes                               | Yes                               |
-| Database upgrade  | Automated minor, manual major| No                 | Manual minor       | Manual minor and major            | Yes                               |
-| Compute scaling   | Horizontal and vertical      | Horizontal and vertical | Enterprise only | Horizontal only                 | Yes                               |
-| Storage scaling   | Yes                          | Manual             | Enterprise only    | No                                | Yes                               |
+| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Controllers for Kubernetes (MCK) |
+|:------------------|:-----------------------------|:-------------------|:-------------------|:-----------------------------------------|
+| Operator upgrade  | Yes                          | Helm upgrade       | Image change       | Yes                               |
+| Database upgrade  | Automated minor, manual major| No                 | Manual minor       | Automated (Enterprise via Ops Manager); manual minor and major (Community) |
+| Compute scaling   | Horizontal and vertical      | Horizontal and vertical | Horizontal and vertical | Horizontal and vertical (Enterprise); horizontal only (Community) |
+| Storage scaling   | Yes                          | Manual             |Yes (Enterprise); No (Community) | Yes (Enterprise); No (Community)                              |
 
 ## MongoDB topologies
 
 The next comparison is focused on replica sets, arbiters, sharding and other node types.
 
-| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Community Operator        | MongoDB Enterprise Operator       |
-|:------------------|:-----------------------------|:-------------------|:-------------------|:----------------------------------|:----------------------------------|
-| Multi-cluster deployment | Yes                   | No                 | No                 | No                                | Yes                               |
-| Sharding          | Yes                          | Yes, another chart | Yes                | No                                | Yes                               |
-| Arbiter           | Yes                          | Yes                | Yes                | Yes                               | Yes                               |
-| Non-voting nodes  | Yes                          | No                 | No                 | No                                | Yes                               |
-| Hidden nodes      | Yes                           | Yes                | Yes                | Yes                               | Yes                               |
-| Network exposure  | Yes                          | Yes                | Manual             | No                                | Yes                               |
-| Split Horizon     | Yes                          | No                 | No                 | Yes                               | Yes                               |
+| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Controllers for Kubernetes (MCK) |
+|:------------------|:-----------------------------|:-------------------|:-------------------|:-----------------------------------------|
+| Multi-cluster deployment | Yes                   | No                 | No                 | Enterprise                        |
+| Sharding          | Yes                          | Yes, another chart | Yes                | Enterprise                        |
+| Arbiter           | Yes                          | Yes                | Yes                | Yes                               |
+| Non-voting nodes  | Yes                          | No                 | No                 | Enterprise                        |
+| Hidden nodes      | Yes                          | Yes                | Yes                | Yes                               |
+| Split Horizon     | Yes                          | No                 | Yes                | Yes                               |
 
 ## Backups
 
 Here are the backup and restore capabilities of each solution.
 
-| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Community Operator        | MongoDB Enterprise Operator       |
-|:------------------|:-----------------------------|:-------------------|:-------------------|:----------------------------------|:----------------------------------|
-| Scheduled backups | Yes                          | No                 | Enterprise only    | No                                | Yes                               |
-| Incremental backups | Yes                         | No                 | Enterprise only    | No                                | No                                |
-| Point-in-time recovery | Yes                     | No                 | No                 | No                                | Yes                               |
-| Logical backups | Yes                            | No                 | No                 | No                                | Yes                               |
-| Physical backups | Yes                           | No                 | No                 | No                                | Yes                               |
+| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Controllers for Kubernetes (MCK) |
+|:------------------|:-----------------------------|:-------------------|:-------------------|:----------------------------------|
+| Scheduled backups | Yes                          | No                 | Enterprise         | Enterprise                        |
+| Incremental backups | Yes                        | No                 | Enterprise         | No                                |
+| Point-in-time recovery | Yes                     | No                 | Enterprise         | Enterprise                        |
+| Logical backups | Yes                            | No                 | No                 | Enterprise                        |
+| Physical backups | Yes                           | No                 | Enterprise         | Enterprise                        |
 
 ## Monitoring
 
 Monitoring is crucial for any operations team.
 
-| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Community Operator        | MongoDB Enterprise Operator       |
-|:------------------|:-----------------------------|:-------------------|:-------------------|:----------------------------------|:----------------------------------|
-| Custom exporters  | Yes, through sidecars        | mongodb-exporter as a sidecar | mongodb-exporter as a sidecar | Integrate with prometheus operator |  Integrate with prometheus operator | 
-| Percona Monitoring and Management (PMM) | Yes    | No                 | No                 | No                                | No                                |
+| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Controllers for Kubernetes (MCK) |
+|:------------------|:-----------------------------|:-------------------|:-------------------|:----------------------------------|
+| Custom exporters  | Yes, through sidecars        | mongodb-exporter as a sidecar | mongodb-exporter as a sidecar | Integrate with prometheus operator |
+| Percona Monitoring and Management (PMM) | Yes    | No                 | No                 | No                                |
 
 ## Miscellaneous
 
 Finally, let’s compare various features that are not a good fit for other categories.
 
-| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Community Operator        | MongoDB Enterprise Operator       |
-|:------------------|:-----------------------------|:-------------------|:-------------------|:----------------------------------|:----------------------------------|
-| Customize MongoDB configuration | Yes            | Yes                | Yes                | No, only some params              | No, only some params              |
-| Helm              | Yes                          | Yes                | Yes, for operator only | Yes, for operator only        | Yes, for operator only            |
-| SSL/TLS           | Yes                          | Yes                | Enterprise only    | Yes                               | Yes                               |
-| Create users/roles| Yes                          | Yes                | No                 | Yes                               | Yes                               |
+| Feature/Product   | Percona Operator for MongoDB | Bitnami Helm Chart | KubeDB for MongoDB | MongoDB Controllers for Kubernetes (MCK) |
+|:------------------|:-----------------------------|:-------------------|:-------------------|:----------------------------------|
+| Customize MongoDB configuration | Yes            | Yes                | Yes                | Limited to some params            |
+| Helm              | Yes                          | Yes                | Yes, for operator only | Yes, for operator only        |
+| SSL/TLS           | Yes                          | Yes                | Enterprise         | Yes                               |
+| Create users/roles| Yes                          | Yes                | No                 | Yes                               |


### PR DESCRIPTION
The MongoDB Community Kubernetes Operator was archived (end-of-life) on December 12, 2025, and the MongoDB Enterprise Kubernetes Operator has also been deprecated. Both are replaced by **MongoDB Controllers for Kubernetes (MCK)**, a single unified open-source operator. All MCK references below apply to the current, actively maintained solution.