### PR TITLE
Fix typo in backup-tutorial.md

### DIFF
--- a/docs/backup-tutorial.md
+++ b/docs/backup-tutorial.md
@@ -66,7 +66,7 @@ cd percona-server-mongodb-operator
 	kubectl apply -f deploy/backup-s3.yaml -n <namespace>
 	```
 
-4. Update your `deploy/cr.yaml` configuration. Specify the following parameters in the `backups` section:
+4. Update your `deploy/cr.yaml` configuration. Specify the following parameters in the `backup` section:
 
     * set the `storages.<NAME>.type` to `s3`. Substitute the `<NAME>` part with some arbitrary name that you will later use to refer this storage when making backups and restores.
     * set the `storages.<NAME>.s3.credentialsSecret` to the name you used to refer your Kubernetes Secret (`my-cluster-name-backup-s3` in the previous step).


### PR DESCRIPTION
The correct section is under the `backup` key, as can be seen in the sample yaml a few lines below